### PR TITLE
Add MorphScraper#set_environment_variable method

### DIFF
--- a/lib/morph_scraper.rb
+++ b/lib/morph_scraper.rb
@@ -25,7 +25,7 @@ class MorphScraper
   end
 
   def environment_variables
-    page = agent.get("https://morph.io/#{scraper}/settings")
+    page = settings_page
     names = page.css('#variables .row .scraper_variables_name input').map { |name| name['value'] }
     values = page.css('#variables .row .scraper_variables_value textarea').map { |value| value.text.strip }
     Hash[names.zip(values)]
@@ -49,6 +49,10 @@ class MorphScraper
   private
 
   attr_reader :scraper
+
+  def settings_page
+    agent.get("https://morph.io/#{scraper}/settings")
+  end
 
   def agent
     @agent ||= Mechanize.new

--- a/lib/morph_scraper.rb
+++ b/lib/morph_scraper.rb
@@ -4,48 +4,69 @@ require 'morph_scraper/environment_variables_form'
 require 'mechanize'
 
 class MorphScraper
-  def initialize(scraper)
-    @scraper = scraper
+  class Scraper
+    def initialize(agent:, scraper:)
+      @agent = agent
+      @scraper = scraper
+    end
+
+    def exists_on_morph?
+      agent.get("https://morph.io/#{scraper}")
+      true
+    rescue Mechanize::ResponseCodeError
+      false
+    end
+
+    def run_scraper
+      response = agent.get("https://morph.io/#{scraper}").forms[1].submit
+      response.code == '200'
+    end
+
+    def environment_variables
+      page = settings_page
+      names = page.css('#variables .row .scraper_variables_name input').map { |name| name['value'] }
+      values = page.css('#variables .row .scraper_variables_value textarea').map { |value| value.text.strip }
+      Hash[names.zip(values)]
+    end
+
+    def set_environment_variable(name, value)
+      form = EnvironmentVariablesForm.new(form: settings_page.forms[1])
+      form.set(name, value)
+    end
+
+    private
+
+    attr_reader :agent, :scraper
+
+    def settings_page
+      agent.get("https://morph.io/#{scraper}/settings")
+    end
   end
 
-  def authenticate_with_github(
+  def initialize(
     username: ENV['MORPH_GITHUB_USERNAME'],
     password: ENV['MORPH_GITHUB_PASSWORD']
   )
-    login = agent.get('https://morph.io/users/auth/github')
-    login.form['login'] = username
-    login.form['password'] = password
-    oauth = login.form.submit
-    response = oauth.link.click
-    response.code == '200'
+    @username = username
+    @password = password
   end
 
-  def run_scraper
-    response = agent.get("https://morph.io/#{scraper}").forms[1].submit
-    response.code == '200'
-  end
-
-  def environment_variables
-    page = settings_page
-    names = page.css('#variables .row .scraper_variables_name input').map { |name| name['value'] }
-    values = page.css('#variables .row .scraper_variables_value textarea').map { |value| value.text.strip }
-    Hash[names.zip(values)]
-  end
-
-  def set_environment_variable(name, value)
-    form = EnvironmentVariablesForm.new(form: settings_page.forms[1])
-    form.set(name, value)
+  def scraper(scraper)
+    Scraper.new(agent: agent, scraper: scraper)
   end
 
   private
 
-  attr_reader :scraper
-
-  def settings_page
-    agent.get("https://morph.io/#{scraper}/settings")
-  end
+  attr_reader :username, :password
 
   def agent
-    @agent ||= Mechanize.new
+    @agent ||= Mechanize.new.tap do |mech|
+      login = mech.get('https://morph.io/users/auth/github')
+      login.form['login'] = username
+      login.form['password'] = password
+      oauth = login.form.submit
+      response = oauth.link.click
+      response.code == '200'
+    end
   end
 end

--- a/lib/morph_scraper.rb
+++ b/lib/morph_scraper.rb
@@ -31,6 +31,21 @@ class MorphScraper
     Hash[names.zip(values)]
   end
 
+  def set_environment_variable(name, value)
+    page = agent.get("https://morph.io/#{scraper}/settings")
+    form = page.forms[1]
+    existing = form.fields.find { |f| f.value == name }
+    if existing
+      form[existing.name.sub(/\[name\]$/, '[value]')] = value
+    else
+      field_id = Time.now.to_i
+      form["scraper[variables_attributes][#{field_id}][name]"] = name
+      form["scraper[variables_attributes][#{field_id}][value]"] = value
+    end
+    response = form.submit
+    response.code == '200'
+  end
+
   private
 
   attr_reader :scraper

--- a/lib/morph_scraper.rb
+++ b/lib/morph_scraper.rb
@@ -1,4 +1,5 @@
 require 'morph_scraper/version'
+require 'morph_scraper/environment_variables_form'
 
 require 'mechanize'
 
@@ -32,18 +33,8 @@ class MorphScraper
   end
 
   def set_environment_variable(name, value)
-    page = agent.get("https://morph.io/#{scraper}/settings")
-    form = page.forms[1]
-    existing = form.fields.find { |f| f.value == name }
-    if existing
-      form[existing.name.sub(/\[name\]$/, '[value]')] = value
-    else
-      field_id = Time.now.to_i
-      form["scraper[variables_attributes][#{field_id}][name]"] = name
-      form["scraper[variables_attributes][#{field_id}][value]"] = value
-    end
-    response = form.submit
-    response.code == '200'
+    form = EnvironmentVariablesForm.new(form: settings_page.forms[1])
+    form.set(name, value)
   end
 
   private

--- a/lib/morph_scraper/environment_variables_form.rb
+++ b/lib/morph_scraper/environment_variables_form.rb
@@ -1,0 +1,24 @@
+class MorphScraper
+  class EnvironmentVariablesForm
+    def initialize(form:)
+      @form = form
+    end
+
+    def set(name, value)
+      existing = form.fields.find { |f| f.value == name }
+      if existing
+        form[existing.name.sub(/\[name\]$/, '[value]')] = value
+      else
+        field_id = Time.now.to_i
+        form["scraper[variables_attributes][#{field_id}][name]"] = name
+        form["scraper[variables_attributes][#{field_id}][value]"] = value
+      end
+      form.submit
+      value
+    end
+
+    private
+
+    attr_reader :form
+  end
+end

--- a/lib/morph_scraper/environment_variables_form.rb
+++ b/lib/morph_scraper/environment_variables_form.rb
@@ -20,7 +20,7 @@ class MorphScraper
 
     attr_reader :form
 
-    def set_form_env_var
+    def set_form_env_var(name, value)
       field_id = Time.now.to_i
       form["scraper[variables_attributes][#{field_id}][name]"] = name
       form["scraper[variables_attributes][#{field_id}][value]"] = value

--- a/lib/morph_scraper/environment_variables_form.rb
+++ b/lib/morph_scraper/environment_variables_form.rb
@@ -9,9 +9,7 @@ class MorphScraper
       if existing
         form[existing.name.sub(/\[name\]$/, '[value]')] = value
       else
-        field_id = Time.now.to_i
-        form["scraper[variables_attributes][#{field_id}][name]"] = name
-        form["scraper[variables_attributes][#{field_id}][value]"] = value
+        set_form_env_var(name, value)
       end
       clean_textareas
       form.submit
@@ -21,6 +19,12 @@ class MorphScraper
     private
 
     attr_reader :form
+
+    def set_form_env_var
+      field_id = Time.now.to_i
+      form["scraper[variables_attributes][#{field_id}][name]"] = name
+      form["scraper[variables_attributes][#{field_id}][value]"] = value
+    end
 
     def clean_textareas
       # Workaround for Morph adding a newline to the beginning of a textarea.

--- a/lib/morph_scraper/environment_variables_form.rb
+++ b/lib/morph_scraper/environment_variables_form.rb
@@ -13,6 +13,7 @@ class MorphScraper
         form["scraper[variables_attributes][#{field_id}][name]"] = name
         form["scraper[variables_attributes][#{field_id}][value]"] = value
       end
+      clean_textareas
       form.submit
       value
     end
@@ -20,5 +21,10 @@ class MorphScraper
     private
 
     attr_reader :form
+
+    def clean_textareas
+      # Workaround for Morph adding a newline to the beginning of a textarea.
+      form.textareas.each { |t| t.value = t.value.strip }
+    end
   end
 end


### PR DESCRIPTION
This allows setting environment variables on a scraper. At the moment we return true when the response status is 200, but this doesn't necessarily mean that things have worked correctly - setting a variable that doesn't start with `MORPH_` will silently fail, for example.